### PR TITLE
Feature #61: auto-sync ISSUE_TRACKER.md at reincarnation, inject at session start

### DIFF
--- a/hooks/context_injector.py
+++ b/hooks/context_injector.py
@@ -88,6 +88,10 @@ def main():
         if tail:
             injection_parts.append(f"## IMMEDIATE CONTEXT (LAST 10 TURNS)\n{tail}")
 
+        tracker = read_file_safe(os.path.join(continuity_dir, "ISSUE_TRACKER.md"))
+        if tracker:
+            injection_parts.append(f"## OPEN TICKETS (ACTIVE WORK)\n{tracker}")
+
         if not injection_parts:
             print(json.dumps({}))
             return

--- a/tests/unit/test_aim_reincarnate.py
+++ b/tests/unit/test_aim_reincarnate.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for scripts/aim_reincarnate.py
+
+Covers:
+- Issue #61: sync_issue_tracker.py is invoked as step 0 before handoff pulse
+- Sync failure is non-fatal (WARN, not abort)
+- venv_python resolution
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+AIM_CLAUDE_ROOT = str(Path(__file__).parent.parent.parent)
+REINCARNATE_PATH = os.path.join(AIM_CLAUDE_ROOT, "scripts", "aim_reincarnate.py")
+
+
+def _load_reincarnate():
+    sys.modules.pop("aim_reincarnate", None)
+    spec = importlib.util.spec_from_file_location("aim_reincarnate", REINCARNATE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("os.getcwd", return_value=AIM_CLAUDE_ROOT):
+        spec.loader.exec_module(mod)
+    return mod
+
+
+class TestReincarnateIssueTrackerSync(unittest.TestCase):
+    """Issue #61: sync_issue_tracker.py must be called as step 0 of reincarnation."""
+
+    def setUp(self):
+        self.mod = _load_reincarnate()
+
+    def _run_main_mocked(self, sync_side_effect=None):
+        """Run main() with all interactive and external calls stubbed."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if sync_side_effect and "sync_issue_tracker" in str(cmd):
+                raise sync_side_effect
+            result = MagicMock()
+            result.stdout = ""
+            result.returncode = 0
+            return result
+
+        with patch("builtins.input", return_value="test intent"), \
+             patch.object(self.mod.subprocess, "run", side_effect=fake_run), \
+             patch.object(self.mod.time, "sleep"), \
+             patch.object(self.mod.os, "environ", {"TMUX": ""}), \
+             patch.object(self.mod.os, "getppid", return_value=1), \
+             patch.object(self.mod.os, "kill"):
+            try:
+                self.mod.main()
+            except (SystemExit, Exception):
+                pass
+        return calls
+
+    def test_sync_issue_tracker_called_before_pulse(self):
+        """sync_issue_tracker.py must appear in subprocess calls before handoff_pulse_generator.py."""
+        calls = self._run_main_mocked()
+        flat = [str(c) for c in calls]
+        sync_idx = next((i for i, c in enumerate(flat) if "sync_issue_tracker" in c), None)
+        pulse_idx = next((i for i, c in enumerate(flat) if "handoff_pulse_generator" in c), None)
+        self.assertIsNotNone(sync_idx, "sync_issue_tracker.py was never called during reincarnation")
+        self.assertIsNotNone(pulse_idx, "handoff_pulse_generator.py was never called during reincarnation")
+        self.assertLess(sync_idx, pulse_idx,
+                        "sync_issue_tracker must be called BEFORE handoff_pulse_generator")
+
+    def test_sync_failure_is_non_fatal(self):
+        """If sync_issue_tracker fails, reincarnation should continue (not abort)."""
+        import subprocess
+        calls = self._run_main_mocked(
+            sync_side_effect=subprocess.CalledProcessError(1, "sync_issue_tracker.py")
+        )
+        flat = [str(c) for c in calls]
+        # Pulse should still have been called despite sync failure
+        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        self.assertTrue(pulse_called,
+                        "Reincarnation aborted after sync failure — sync must be non-fatal")
+
+    def test_sync_timeout_is_non_fatal(self):
+        """If sync_issue_tracker times out, reincarnation should continue."""
+        import subprocess
+        calls = self._run_main_mocked(
+            sync_side_effect=subprocess.TimeoutExpired("sync_issue_tracker.py", 15)
+        )
+        flat = [str(c) for c in calls]
+        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        self.assertTrue(pulse_called,
+                        "Reincarnation aborted after sync timeout — must be non-fatal")
+
+    def test_sync_uses_scripts_dir(self):
+        """sync_issue_tracker.py must be resolved from AIM_ROOT/scripts/, not hardcoded."""
+        calls = self._run_main_mocked()
+        flat = [str(c) for c in calls]
+        sync_call = next((c for c in flat if "sync_issue_tracker" in c), None)
+        self.assertIsNotNone(sync_call)
+        self.assertIn("scripts", sync_call,
+                      "sync_issue_tracker.py path must include 'scripts/' directory")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -392,6 +392,26 @@ class TestContextInjectorFileInjection(unittest.TestCase):
         self.assertIn("IMMEDIATE CONTEXT", ctx)
         self.assertIn("TAIL CONTENT", ctx)
 
+    def test_issue_tracker_injected_with_header(self):
+        self._write("ISSUE_TRACKER.md", "* #61 - Auto-sync issue tracker")
+        result = self._run({"session_id": "s1"})
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("OPEN TICKETS", ctx)
+        self.assertIn("#61", ctx)
+
+    def test_all_five_files_injected(self):
+        self._write("ANCHOR.md", "A")
+        self._write("CORE_MEMORY.md", "B")
+        self._write("CURRENT_PULSE.md", "C")
+        self._write("FALLBACK_TAIL.md", "D")
+        self._write("ISSUE_TRACKER.md", "E")
+        result = self._run({"session_id": "s1"})
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("SESSION ONBOARDING", ctx)
+        self.assertIn("END ONBOARDING", ctx)
+        for marker in ["MEMORY ANCHOR", "CORE MEMORY", "PROJECT MOMENTUM", "IMMEDIATE CONTEXT", "OPEN TICKETS"]:
+            self.assertIn(marker, ctx)
+
     def test_all_four_files_injected(self):
         self._write("ANCHOR.md", "A")
         self._write("CORE_MEMORY.md", "B")


### PR DESCRIPTION
## Summary

ISSUE_TRACKER.md was a manual-only artifact — it only existed if someone ran `aim-claude sync-issues`. This meant the wake-up prompt in `aim_reincarnate.py` referenced it but it was never reliably there.

**Two changes:**

**`scripts/aim_reincarnate.py` — step 0 at end of session**
- `sync_issue_tracker.py` now runs as the first step before the handoff pulse
- 15s timeout, failure is non-fatal (WARN + continue) — GitHub API hiccup shouldn't kill the reincarnation
- Guarantees `continuity/ISSUE_TRACKER.md` is current before the handoff package is written

**`hooks/context_injector.py` — injection at session start**
- `ISSUE_TRACKER.md` added to the JIT context injection list
- Fires on first tool call of every new Claude Code session
- New agent sees open tickets immediately, zero extra effort

## Test plan
- [x] 4 tests in `test_aim_reincarnate.py`: sync called before pulse, failure non-fatal, timeout non-fatal, uses scripts/ path
- [x] 2 tests in `test_hooks.py`: ISSUE_TRACKER injected with correct header, all 5 files together
- [x] Full suite: 585 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)