### PR TITLE
Feature: Add /reincarnation slash command (Closes #68)

### DIFF
--- a/.claude/commands/reincarnation.md
+++ b/.claude/commands/reincarnation.md
@@ -1,0 +1,46 @@
+---
+description: A.I.M. Reincarnation Protocol — session boundary handoff. Generates a pulse, syncs state, and prepares the next agent vessel.
+argument-hint: [Commander's Intent for the next agent]
+allowed-tools: [Bash, Read, Write]
+---
+
+# A.I.M. REINCARNATION PROTOCOL
+
+You are executing the end-of-session handoff. Follow these steps exactly.
+
+## Commander's Intent
+
+$ARGUMENTS
+
+If `$ARGUMENTS` is empty, ask the user:
+> "What is your Commander's Intent for the next agent session?"
+Then use their response as the intent for all downstream steps.
+
+## Execution Steps
+
+### Step 1 — Run the reincarnation pipeline
+Run the full reincarnation script with the Commander's Intent as the argument:
+
+```bash
+python3 scripts/aim_reincarnate.py "<Commander's Intent>"
+```
+
+This script will:
+1. Sync `continuity/ISSUE_TRACKER.md` from GitHub (non-fatal if offline)
+2. Generate `HANDOFF.md` and `continuity/REINCARNATION_GAMEPLAN.md` via `handoff_pulse_generator.py`
+3. Spawn the next agent vessel in tmux (or print attach instructions if not in tmux)
+4. Teleport — switch the terminal to the new session
+
+### Step 2 — Run T1 session summarizer
+Before the session closes, flush the session transcript to `memory/hourly/`:
+
+```bash
+python3 hooks/session_summarizer.py --light
+```
+
+### Step 3 — Confirm handoff
+Read `HANDOFF.md` and print the final **Operator Directive** section so the user can confirm the next agent will receive the correct mission context.
+
+---
+
+> **Note:** If tmux is not available, the script will print the attach command. The current Claude Code session is not automatically terminated — the user should close it manually after verifying the new vessel is running.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-# Claude Code
+# Claude Code — ignore personal config but track project commands
 .claude/
+!.claude/commands/
+!.claude/commands/**
 memory/
 
 # WSL artifacts

--- a/tests/unit/test_aim_reincarnate.py
+++ b/tests/unit/test_aim_reincarnate.py
@@ -103,5 +103,72 @@ class TestReincarnateIssueTrackerSync(unittest.TestCase):
                       "sync_issue_tracker.py path must include 'scripts/' directory")
 
 
+class TestReincarnateCliArg(unittest.TestCase):
+    """Issue #68: intent can be passed as a CLI arg to bypass interactive input()."""
+
+    def setUp(self):
+        self.mod = _load_reincarnate()
+
+    def _run_main_with_argv(self, argv):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            result.returncode = 0
+            return result
+
+        with patch.object(sys, "argv", ["aim_reincarnate.py"] + argv), \
+             patch.object(self.mod.subprocess, "run", side_effect=fake_run), \
+             patch.object(self.mod.time, "sleep"), \
+             patch.object(self.mod.os, "environ", {"TMUX": ""}), \
+             patch.object(self.mod.os, "getppid", return_value=1), \
+             patch.object(self.mod.os, "kill"), \
+             patch("builtins.input") as mock_input:
+            try:
+                self.mod.main()
+            except (SystemExit, Exception):
+                pass
+            return calls, mock_input
+
+    def test_cli_arg_bypasses_input(self):
+        """When intent is supplied as argv, input() must not be called."""
+        _, mock_input = self._run_main_with_argv(["Continue the roadmap"])
+        mock_input.assert_not_called()
+
+    def test_cli_arg_multi_word(self):
+        """Multi-word intent passed as argv is joined and used."""
+        calls, mock_input = self._run_main_with_argv(["Fix", "issue", "42"])
+        mock_input.assert_not_called()
+        flat = [str(c) for c in calls]
+        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        self.assertTrue(pulse_called)
+
+    def test_no_argv_falls_back_to_input(self):
+        """When no argv is supplied, input() is called for Commander's Intent."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            result.returncode = 0
+            return result
+
+        with patch.object(sys, "argv", ["aim_reincarnate.py"]), \
+             patch.object(self.mod.subprocess, "run", side_effect=fake_run), \
+             patch.object(self.mod.time, "sleep"), \
+             patch.object(self.mod.os, "environ", {"TMUX": ""}), \
+             patch.object(self.mod.os, "getppid", return_value=1), \
+             patch.object(self.mod.os, "kill"), \
+             patch("builtins.input", return_value="manual intent") as mock_input:
+            try:
+                self.mod.main()
+            except (SystemExit, Exception):
+                pass
+        mock_input.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_hooks_session_summarizer.py
+++ b/tests/unit/test_hooks_session_summarizer.py
@@ -376,14 +376,16 @@ class TestProcessTranscriptLightMode:
     def test_hourly_file_contains_session_id(self):
         path = self._write_transcript([USER_MSG])
         self.mod.process_transcript(path, is_light_mode=True)
-        hourly_path = os.path.join(self.mod.HOURLY_DIR, os.listdir(self.mod.HOURLY_DIR)[0])
+        date_files = [f for f in os.listdir(self.mod.HOURLY_DIR) if f != "seed.md"]
+        hourly_path = os.path.join(self.mod.HOURLY_DIR, date_files[0])
         content = open(hourly_path).read()
         assert "sess-abc" in content
 
     def test_hourly_file_contains_user_text(self):
         path = self._write_transcript([USER_MSG])
         self.mod.process_transcript(path, is_light_mode=True)
-        hourly_path = os.path.join(self.mod.HOURLY_DIR, os.listdir(self.mod.HOURLY_DIR)[0])
+        date_files = [f for f in os.listdir(self.mod.HOURLY_DIR) if f != "seed.md"]
+        hourly_path = os.path.join(self.mod.HOURLY_DIR, date_files[0])
         content = open(hourly_path).read()
         assert "Hello AIM" in content
 
@@ -447,7 +449,8 @@ class TestProcessTranscriptLLMMode:
         self.mod.generate_reasoning = MagicMock(return_value="## NARRATIVE OUTPUT")
         path = self._write_transcript([USER_MSG])
         self.mod.process_transcript(path, is_light_mode=False)
-        hourly_path = os.path.join(self.mod.HOURLY_DIR, os.listdir(self.mod.HOURLY_DIR)[0])
+        date_files = [f for f in os.listdir(self.mod.HOURLY_DIR) if f != "seed.md"]
+        hourly_path = os.path.join(self.mod.HOURLY_DIR, date_files[0])
         content = open(hourly_path).read()
         assert "NARRATIVE OUTPUT" in content
 


### PR DESCRIPTION
## Summary
- Adds `.claude/commands/reincarnation.md` — project-local slash command that orchestrates the full A.I.M. reincarnation pipeline (sync issues → pulse → session summarizer → teleport)
- Updates `.gitignore` to allow `.claude/commands/` to be tracked in git
- Updates `aim_reincarnate.py` (in shared `aim` repo via symlink) to accept Commander's Intent as a CLI arg, enabling non-interactive use from the slash command

## Usage
```
/reincarnation Continue the roadmap — fix issue 42 next
```
Or without args — Claude will prompt for intent interactively.

## TDD
- 3 new tests for CLI arg bypass (`test_cli_arg_bypasses_input`, `test_cli_arg_multi_word`, `test_no_argv_falls_back_to_input`) — all GREEN
- 453 total tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)