### PR TITLE
Feature: /reincarnation — live agent writes gameplan (Closes #77)

### DIFF
--- a/.claude/commands/reincarnation.md
+++ b/.claude/commands/reincarnation.md
@@ -1,41 +1,62 @@
 ---
-description: A.I.M. Reincarnation Protocol — end-of-session handoff. Appends your personalized message to REINCARNATION_GAMEPLAN.md as Commander's Intent, then prepares the next agent vessel.
+description: A.I.M. Reincarnation Protocol — end-of-session handoff. The living agent writes its own gameplan (soul/essence/trajectory), then passes the baton to a fresh Claude vessel.
 argument-hint: "[personalized message for the next agent]"
-allowed-tools: [Bash, Read]
+allowed-tools: [Bash, Read, Write]
 ---
 
 # A.I.M. REINCARNATION PROTOCOL
 
-You are executing the end-of-session handoff. The personalized message will be appended to the bottom of `continuity/REINCARNATION_GAMEPLAN.md` as `**Commander's Intent:**`.
+You are the dying agent. You still have full context. You are about to pass the baton.
+Before the script runs, YOU must write the gameplan — not a cold LLM reading a transcript.
 
-## Commander's Intent
+## Step 1 — Get Commander's Intent
 
 $ARGUMENTS
 
 If `$ARGUMENTS` is empty, ask the user:
 > "What is your Commander's Intent for the next agent? (appended to REINCARNATION_GAMEPLAN.md)"
-Then use their response as the intent for all downstream steps.
 
-## Execution Steps
+## Step 2 — Write REINCARNATION_GAMEPLAN.md (YOU write this, right now)
 
-### Step 1 — Run the reincarnation pipeline
+Using your full live context of this session, write `continuity/REINCARNATION_GAMEPLAN.md`.
+Do NOT summarize mechanically. Capture the soul of the session.
 
-Run with the Commander's Intent as the argument:
+Follow this structure exactly:
 
-```bash
-python3 scripts/aim_reincarnate.py "<Commander's Intent>"
 ```
+# REINCARNATION GAMEPLAN
 
-This script will:
-1. Sync `continuity/ISSUE_TRACKER.md` from GitHub (non-fatal if offline)
-2. Generate `continuity/REINCARNATION_GAMEPLAN.md` — the LLM battle plan with `**Commander's Intent:** <your message>` appended at the bottom
-3. Generate `HANDOFF.md` — the next agent's front door
-4. Spawn the next agent vessel in tmux and teleport
+## ⚠️ URGENT DIRECTIVE FOR THE INCOMING AGENT
+You are waking up in the middle of a high-momentum development cycle.
+The previous agent has distilled the session heartbeat into these rigid directives:
 
-### Step 2 — Confirm the gameplan
-
-Read `continuity/REINCARNATION_GAMEPLAN.md` and print the final `**Commander's Intent:**` line so the user can confirm their message was recorded correctly.
+[YOUR CONTENT — address the following:]
+- What was the core theme and technical momentum of this session?
+- What was the "Eureka" direction — the thing that finally clicked or the path that proved correct?
+- What was thrashed on, debated, or pivoted away from? (So the next agent doesn't repeat it)
+- What is the active trajectory — where were things heading when the session ended?
+- 3–5 rigid, numbered battle steps for the next agent to execute immediately upon waking.
+  Focus only on active momentum. Ignore closed/abandoned directions.
 
 ---
+**Commander's Intent:** <user message from Step 1>
+**Timestamp:** <current datetime>
+```
 
-> **Note:** If tmux is not available, the script prints an attach command. Close this Claude Code session manually after verifying the new vessel is running.
+Write this file now using the Write tool before proceeding.
+
+## Step 3 — Run the reincarnation pipeline
+
+```bash
+python3 scripts/aim_reincarnate.py "<Commander's Intent from Step 1>"
+```
+
+This will:
+1. Sync `continuity/ISSUE_TRACKER.md`
+2. Run scrivener pipeline (T1 + System 1)
+3. Refresh `CURRENT_PULSE.md` and `HANDOFF.md` (timestamps only — does NOT overwrite your gameplan)
+4. Spawn a new Claude vessel in tmux and teleport
+
+## Step 4 — Confirm
+
+Read the final line of `continuity/REINCARNATION_GAMEPLAN.md` and confirm the Commander's Intent was recorded correctly.

--- a/tests/unit/test_aim_reincarnate.py
+++ b/tests/unit/test_aim_reincarnate.py
@@ -262,6 +262,51 @@ class TestReincarnateScrivenerPipeline(unittest.TestCase):
                       "session_summarizer must be invoked with --light flag")
 
 
+class TestReincarnateGameplanNotOverwritten(unittest.TestCase):
+    """Issue #77: aim_reincarnate.py must NOT pass intent to handoff_pulse_generator.py.
+    The gameplan is written by the live agent (via /reincarnation command) before the
+    script runs. Passing intent as argv would overwrite it with a cold LLM analysis."""
+
+    def setUp(self):
+        self.mod = _load_reincarnate()
+
+    def _run_main_mocked(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            result.returncode = 0
+            return result
+
+        with patch("builtins.input", return_value="test intent"), \
+             patch.object(self.mod.subprocess, "run", side_effect=fake_run), \
+             patch.object(self.mod.time, "sleep"), \
+             patch.object(self.mod.os, "environ", {"TMUX": ""}), \
+             patch.object(self.mod.os, "getppid", return_value=1), \
+             patch.object(self.mod.os, "kill"):
+            try:
+                self.mod.main()
+            except (SystemExit, Exception):
+                pass
+        return calls
+
+    def test_pulse_generator_called_without_intent_arg(self):
+        """handoff_pulse_generator.py must be called with no extra args — the live
+        agent owns the gameplan; passing intent would trigger a cold LLM overwrite."""
+        calls = self._run_main_mocked()
+        pulse_call = next(
+            (c for c in calls if "handoff_pulse_generator" in str(c)), None
+        )
+        self.assertIsNotNone(pulse_call, "handoff_pulse_generator.py was never called")
+        # The call list should be [venv_python, script_path] — no intent appended
+        self.assertEqual(
+            len(pulse_call), 2,
+            f"handoff_pulse_generator.py must be called with no extra args, got: {pulse_call}"
+        )
+
+
 class TestReincarnateClaudeHandoff(unittest.TestCase):
     """Issue #75: aim_reincarnate.py must spawn claude (not gemini) and
     reference CLAUDE.md in the wake-up prompt."""


### PR DESCRIPTION
## Summary
The living agent now authors `REINCARNATION_GAMEPLAN.md` directly via the `/reincarnation` command, while it still has full session context — capturing the soul, eureka direction, and active trajectory. A cold LLM reading a transcript can no longer overwrite it.

## Changes
- **`.claude/commands/reincarnation.md`** — Step 2 instructs Claude to write the gameplan itself (soul/essence/battle plan template) before calling the script. Uses the original prompt language: essence, heartbeat, eureka direction, what was thrashed, 3-5 rigid battle steps.
- **`aim_reincarnate.py`** (aim repo) — `handoff_pulse_generator.py` called without intent arg. Passing intent previously triggered `generate_reincarnation_gameplan()`, overwriting the live agent's work.

## TDD
1 RED test → GREEN. 462 total passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)