### PR TITLE
Fix: Claude Code JSONL pulse generator — replaces Gemini extraction (Closes #78)

### DIFF
--- a/scripts/aim_reincarnate.py
+++ b/scripts/aim_reincarnate.py
@@ -62,7 +62,7 @@ def main():
 
     try:
         subprocess.run(
-            [venv_python, os.path.join(AIM_ROOT, "src", "handoff_pulse_generator.py")],
+            [venv_python, os.path.join(AIM_ROOT, "scripts", "handoff_pulse_claude.py")],
             cwd=AIM_ROOT, check=True
         )
     except subprocess.CalledProcessError as e:

--- a/scripts/handoff_pulse_claude.py
+++ b/scripts/handoff_pulse_claude.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+handoff_pulse_claude.py — Claude Code-specific handoff pulse generator (Issue #78)
+
+Replaces the Gemini-specific handoff_pulse_generator.py for aim-claude.
+
+Responsibilities:
+  1. Find the current session JSONL from ~/.claude/projects/<hash>/
+  2. Extract the last 5 user+assistant turns (no LLM — pure mechanical extraction)
+  3. Write CURRENT_PULSE.md
+  4. Refresh HANDOFF.md from a static template (timestamp only changes)
+
+Anti-cannibalization: if the newest JSONL has < 15 lines (e.g. a fresh wake-up
+session), use the previous one so we don't overwrite a full history with a stub.
+"""
+import glob
+import json
+import os
+import sys
+from datetime import datetime
+
+# ---------------------------------------------------------------------------
+# Root discovery
+# ---------------------------------------------------------------------------
+
+def _find_aim_root():
+    for start in [os.path.abspath(os.getcwd()),
+                  os.path.dirname(os.path.abspath(__file__))]:
+        current = start
+        while current != "/":
+            if os.path.exists(os.path.join(current, "core", "CONFIG.json")):
+                return current
+            current = os.path.dirname(current)
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+AIM_ROOT = _find_aim_root()
+CONTINUITY_DIR = os.path.join(AIM_ROOT, "continuity")
+HANDOFF_PATH = os.path.join(AIM_ROOT, "HANDOFF.md")
+
+# ---------------------------------------------------------------------------
+# Static HANDOFF.md template — only the timestamp varies
+# ---------------------------------------------------------------------------
+
+HANDOFF_TEMPLATE = """\
+# A.I.M. Continuity Handoff
+
+## ⚠️ CRITICAL INSTRUCTION FOR INCOMING AGENT ⚠️
+You are waking up in the middle of a continuous operational loop.
+To prevent hallucination, you must establish **Epistemic Certainty** regarding
+the previous agent's actions before you write any code.
+
+### The Continuity Protocol (The Reincarnation Gameplan)
+1. Read `continuity/REINCARNATION_GAMEPLAN.md` — the soul/battle plan written by the previous agent.
+2. Read `continuity/CURRENT_PULSE.md` — the last 5 turns of the session (raw, no LLM).
+3. Read `continuity/ISSUE_TRACKER.md` — all open and closed tickets.
+4. (Optional) Read `continuity/LAST_SESSION_FLIGHT_RECORDER.md` ONLY IF the Gameplan explicitly requires historical context extraction.
+5. Do not blindly assume success. Verify state via file reads or tests.
+
+---
+**Timestamp:** {timestamp}
+"""
+
+# ---------------------------------------------------------------------------
+# JSONL discovery
+# ---------------------------------------------------------------------------
+
+def find_transcripts():
+    """Return all JSONL session transcripts for this project, sorted by mtime ascending."""
+    project_hash = "-" + AIM_ROOT.lstrip("/").replace("/", "-")
+    proj_dir = os.path.expanduser(f"~/.claude/projects/{project_hash}")
+    if not os.path.isdir(proj_dir):
+        return []
+    files = glob.glob(os.path.join(proj_dir, "*.jsonl"))
+    files.sort(key=os.path.getmtime)
+    return files
+
+
+def select_transcript(transcripts):
+    """Apply anti-cannibalization check: if newest JSONL has < 15 lines and a
+    previous session exists, return the previous one instead."""
+    if not transcripts:
+        return None
+    newest = transcripts[-1]
+    if len(transcripts) > 1:
+        try:
+            with open(newest, "r") as f:
+                line_count = sum(1 for _ in f)
+            if line_count < 15:
+                return transcripts[-2]
+        except Exception:
+            pass
+    return newest
+
+# ---------------------------------------------------------------------------
+# Turn extraction
+# ---------------------------------------------------------------------------
+
+def extract_last_turns(jsonl_path, n=5):
+    """Extract the last n user+assistant turns from a JSONL file.
+
+    Skips: snapshot entries, tool_result blocks, thinking blocks.
+    Returns a list of dicts: {role, text, timestamp}
+    """
+    turns = []
+    try:
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                if obj.get("type") == "snapshot" or obj.get("isSnapshotUpdate"):
+                    continue
+
+                msg = obj.get("message", {})
+                role = msg.get("role", "")
+                if role not in ("user", "assistant"):
+                    continue
+
+                content = msg.get("content", "")
+                ts = obj.get("timestamp", "")
+
+                text = ""
+                if isinstance(content, str):
+                    text = content.strip()
+                elif isinstance(content, list):
+                    parts = []
+                    for item in content:
+                        if not isinstance(item, dict):
+                            continue
+                        itype = item.get("type", "")
+                        if itype == "text":
+                            t = item.get("text", "").strip()
+                            if t:
+                                parts.append(t)
+                        # skip: tool_result, thinking, tool_use, image
+                    text = " ".join(parts)
+
+                if text:
+                    turns.append({"role": role, "text": text, "timestamp": ts})
+
+    except Exception:
+        pass
+
+    return turns[-n:] if len(turns) > n else turns
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+def _atomic_write(path, content):
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+
+
+def write_current_pulse(turns):
+    """Write CURRENT_PULSE.md from extracted turns — no LLM."""
+    now = datetime.now()
+    date_str = now.strftime("%Y-%m-%d")
+    time_str = now.strftime("%H:%M:%S")
+
+    lines = [
+        f"---",
+        f"date: {date_str}",
+        f'time: "{time_str}"',
+        f"type: handoff",
+        f"---",
+        f"",
+        f"# A.I.M. Context Pulse: {date_str} {time_str}",
+        f"",
+        f"## Last {len(turns)} Turn(s)",
+        f"",
+    ]
+
+    for turn in turns:
+        role_label = "USER" if turn["role"] == "user" else "A.I.M."
+        ts = turn.get("timestamp", "")
+        lines.append(f"### {role_label} ({ts})")
+        lines.append(turn["text"])
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+    if not turns:
+        lines.append("*(No session turns found)*")
+        lines.append("")
+
+    lines.append('"I believe I\'ve made my point." — **A.I.M. (Auto-Pulse)**')
+
+    os.makedirs(CONTINUITY_DIR, exist_ok=True)
+    _atomic_write(os.path.join(CONTINUITY_DIR, "CURRENT_PULSE.md"), "\n".join(lines))
+
+
+def write_handoff():
+    """Refresh HANDOFF.md from the static template with a current timestamp."""
+    content = HANDOFF_TEMPLATE.format(
+        timestamp=datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
+    _atomic_write(HANDOFF_PATH, content)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    transcripts = find_transcripts()
+    transcript = select_transcript(transcripts)
+
+    if transcript:
+        turns = extract_last_turns(transcript, n=5)
+    else:
+        turns = []
+        print("[handoff_pulse_claude] No JSONL transcripts found — writing empty pulse.")
+
+    write_current_pulse(turns)
+    write_handoff()
+    print("[handoff_pulse_claude] CURRENT_PULSE.md and HANDOFF.md refreshed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_aim_reincarnate.py
+++ b/tests/unit/test_aim_reincarnate.py
@@ -60,15 +60,15 @@ class TestReincarnateIssueTrackerSync(unittest.TestCase):
         return calls
 
     def test_sync_issue_tracker_called_before_pulse(self):
-        """sync_issue_tracker.py must appear in subprocess calls before handoff_pulse_generator.py."""
+        """sync_issue_tracker.py must appear in subprocess calls before handoff_pulse_claude.py."""
         calls = self._run_main_mocked()
         flat = [str(c) for c in calls]
         sync_idx = next((i for i, c in enumerate(flat) if "sync_issue_tracker" in c), None)
-        pulse_idx = next((i for i, c in enumerate(flat) if "handoff_pulse_generator" in c), None)
+        pulse_idx = next((i for i, c in enumerate(flat) if "handoff_pulse_claude" in c), None)
         self.assertIsNotNone(sync_idx, "sync_issue_tracker.py was never called during reincarnation")
-        self.assertIsNotNone(pulse_idx, "handoff_pulse_generator.py was never called during reincarnation")
+        self.assertIsNotNone(pulse_idx, "handoff_pulse_claude.py was never called during reincarnation")
         self.assertLess(sync_idx, pulse_idx,
-                        "sync_issue_tracker must be called BEFORE handoff_pulse_generator")
+                        "sync_issue_tracker must be called BEFORE handoff_pulse_claude")
 
     def test_sync_failure_is_non_fatal(self):
         """If sync_issue_tracker fails, reincarnation should continue (not abort)."""
@@ -78,7 +78,7 @@ class TestReincarnateIssueTrackerSync(unittest.TestCase):
         )
         flat = [str(c) for c in calls]
         # Pulse should still have been called despite sync failure
-        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        pulse_called = any("handoff_pulse_claude" in c for c in flat)
         self.assertTrue(pulse_called,
                         "Reincarnation aborted after sync failure — sync must be non-fatal")
 
@@ -89,7 +89,7 @@ class TestReincarnateIssueTrackerSync(unittest.TestCase):
             sync_side_effect=subprocess.TimeoutExpired("sync_issue_tracker.py", 15)
         )
         flat = [str(c) for c in calls]
-        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        pulse_called = any("handoff_pulse_claude" in c for c in flat)
         self.assertTrue(pulse_called,
                         "Reincarnation aborted after sync timeout — must be non-fatal")
 
@@ -142,7 +142,7 @@ class TestReincarnateCliArg(unittest.TestCase):
         calls, mock_input = self._run_main_with_argv(["Fix", "issue", "42"])
         mock_input.assert_not_called()
         flat = [str(c) for c in calls]
-        pulse_called = any("handoff_pulse_generator" in c for c in flat)
+        pulse_called = any("handoff_pulse_claude" in c for c in flat)
         self.assertTrue(pulse_called)
 
     def test_no_argv_falls_back_to_input(self):
@@ -211,15 +211,15 @@ class TestReincarnateScrivenerPipeline(unittest.TestCase):
         )
 
     def test_summarizer_called_before_pulse(self):
-        """session_summarizer must run before handoff_pulse_generator (step 0.5 < step 1)."""
+        """session_summarizer must run before handoff_pulse_claude (step 0.5 < step 1)."""
         calls = self._run_main_mocked()
         flat = [str(c) for c in calls]
         summ_idx = next((i for i, c in enumerate(flat) if "session_summarizer" in c), None)
-        pulse_idx = next((i for i, c in enumerate(flat) if "handoff_pulse_generator" in c), None)
+        pulse_idx = next((i for i, c in enumerate(flat) if "handoff_pulse_claude" in c), None)
         self.assertIsNotNone(summ_idx, "session_summarizer.py never called")
-        self.assertIsNotNone(pulse_idx, "handoff_pulse_generator.py never called")
+        self.assertIsNotNone(pulse_idx, "handoff_pulse_claude.py never called")
         self.assertLess(summ_idx, pulse_idx,
-                        "session_summarizer must run BEFORE handoff_pulse_generator")
+                        "session_summarizer must run BEFORE handoff_pulse_claude")
 
     def test_summarizer_called_after_sync(self):
         """session_summarizer must run after sync_issue_tracker (step 0 < step 0.5)."""
@@ -240,7 +240,7 @@ class TestReincarnateScrivenerPipeline(unittest.TestCase):
         )
         flat = [str(c) for c in calls]
         self.assertTrue(
-            any("handoff_pulse_generator" in c for c in flat),
+            any("handoff_pulse_claude" in c for c in flat),
             "Reincarnation aborted after summarizer failure — must be non-fatal"
         )
 
@@ -262,8 +262,57 @@ class TestReincarnateScrivenerPipeline(unittest.TestCase):
                       "session_summarizer must be invoked with --light flag")
 
 
+class TestReincarnateUsesLocalPulseScript(unittest.TestCase):
+    """Issue #78: aim_reincarnate.py must call handoff_pulse_claude.py (local,
+    Claude Code JSONL) not handoff_pulse_claude.py (shared, Gemini JSON)."""
+
+    def setUp(self):
+        self.mod = _load_reincarnate()
+
+    def _run_main_mocked(self):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            result.returncode = 0
+            return result
+
+        with patch("builtins.input", return_value="test intent"), \
+             patch.object(self.mod.subprocess, "run", side_effect=fake_run), \
+             patch.object(self.mod.time, "sleep"), \
+             patch.object(self.mod.os, "environ", {"TMUX": ""}), \
+             patch.object(self.mod.os, "getppid", return_value=1), \
+             patch.object(self.mod.os, "kill"):
+            try:
+                self.mod.main()
+            except (SystemExit, Exception):
+                pass
+        return calls
+
+    def test_calls_local_pulse_script_not_shared(self):
+        calls = self._run_main_mocked()
+        flat = [str(c) for c in calls]
+        self.assertTrue(
+            any("handoff_pulse_claude" in c for c in flat),
+            "aim_reincarnate.py must call handoff_pulse_claude.py (local)"
+        )
+        self.assertFalse(
+            any("handoff_pulse_generator" in c for c in flat),
+            "aim_reincarnate.py must NOT call handoff_pulse_generator.py (shared/Gemini)"
+        )
+
+    def test_pulse_script_in_scripts_dir(self):
+        calls = self._run_main_mocked()
+        flat = [str(c) for c in calls]
+        pulse_call = next((c for c in flat if "handoff_pulse_claude" in c), None)
+        self.assertIsNotNone(pulse_call)
+        self.assertIn("scripts", pulse_call)
+
+
 class TestReincarnateGameplanNotOverwritten(unittest.TestCase):
-    """Issue #77: aim_reincarnate.py must NOT pass intent to handoff_pulse_generator.py.
+    """Issue #77: aim_reincarnate.py must NOT pass intent to handoff_pulse_claude.py.
     The gameplan is written by the live agent (via /reincarnation command) before the
     script runs. Passing intent as argv would overwrite it with a cold LLM analysis."""
 
@@ -293,17 +342,17 @@ class TestReincarnateGameplanNotOverwritten(unittest.TestCase):
         return calls
 
     def test_pulse_generator_called_without_intent_arg(self):
-        """handoff_pulse_generator.py must be called with no extra args — the live
+        """handoff_pulse_claude.py must be called with no extra args — the live
         agent owns the gameplan; passing intent would trigger a cold LLM overwrite."""
         calls = self._run_main_mocked()
         pulse_call = next(
-            (c for c in calls if "handoff_pulse_generator" in str(c)), None
+            (c for c in calls if "handoff_pulse_claude" in str(c)), None
         )
-        self.assertIsNotNone(pulse_call, "handoff_pulse_generator.py was never called")
+        self.assertIsNotNone(pulse_call, "handoff_pulse_claude.py was never called")
         # The call list should be [venv_python, script_path] — no intent appended
         self.assertEqual(
             len(pulse_call), 2,
-            f"handoff_pulse_generator.py must be called with no extra args, got: {pulse_call}"
+            f"handoff_pulse_claude.py must be called with no extra args, got: {pulse_call}"
         )
 
 

--- a/tests/unit/test_handoff_pulse_claude.py
+++ b/tests/unit/test_handoff_pulse_claude.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for scripts/handoff_pulse_claude.py (Issue #78)
+
+Covers:
+- JSONL discovery via Claude Code project hash
+- Last-5-turns extraction (user + assistant only, skip snapshots/tool_results/thinking)
+- Anti-cannibalization: newest JSONL < 15 lines → use previous session
+- CURRENT_PULSE.md written with correct format
+- HANDOFF.md written from static template with fresh timestamp
+- Graceful handling of missing/empty JSONL dir
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "scripts"))
+SCRIPT_PATH = os.path.join(SCRIPTS_DIR, "handoff_pulse_claude.py")
+AIM_CLAUDE_ROOT = str(Path(__file__).parent.parent.parent)
+
+
+def _load_mod(tmp_root):
+    sys.modules.pop("handoff_pulse_claude", None)
+    spec = importlib.util.spec_from_file_location("handoff_pulse_claude", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    with patch("os.getcwd", return_value=tmp_root):
+        spec.loader.exec_module(mod)
+    mod.AIM_ROOT = tmp_root
+    mod.CONTINUITY_DIR = os.path.join(tmp_root, "continuity")
+    mod.HANDOFF_PATH = os.path.join(tmp_root, "HANDOFF.md")
+    return mod
+
+
+def _make_tmp_root():
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, "continuity"))
+    os.makedirs(os.path.join(d, "core"))
+    with open(os.path.join(d, "core", "CONFIG.json"), "w") as f:
+        json.dump({}, f)
+    return d
+
+
+def _make_jsonl(path, turns):
+    """Write a list of turn dicts as JSONL."""
+    with open(path, "w") as f:
+        for t in turns:
+            f.write(json.dumps(t) + "\n")
+
+
+def _user(text, ts="2026-04-02T00:00:01Z"):
+    return {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]},
+            "sessionId": "sess-test", "timestamp": ts}
+
+
+def _assistant(text, ts="2026-04-02T00:00:02Z"):
+    return {"type": "assistant", "message": {"role": "assistant",
+            "content": [{"type": "text", "text": text}]},
+            "sessionId": "sess-test", "timestamp": ts}
+
+
+def _snapshot():
+    return {"type": "snapshot", "isSnapshotUpdate": True, "snapshot": {}}
+
+
+def _tool_result():
+    return {"type": "assistant", "message": {"role": "assistant",
+            "content": [{"type": "tool_result", "content": "output"}]},
+            "sessionId": "sess-test", "timestamp": "2026-04-02T00:00:03Z"}
+
+
+class TestFindTranscripts(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_returns_empty_when_no_project_dir(self):
+        self.mod.AIM_ROOT = "/nonexistent/path"
+        result = self.mod.find_transcripts()
+        self.assertEqual(result, [])
+
+    def test_discovers_jsonl_files(self):
+        aim_root = self.tmp
+        proj_hash = "-" + aim_root.lstrip("/").replace("/", "-")
+        proj_dir = os.path.expanduser(f"~/.claude/projects/{proj_hash}")
+        os.makedirs(proj_dir, exist_ok=True)
+        p = os.path.join(proj_dir, "session.jsonl")
+        _make_jsonl(p, [_user("hello")])
+        self.mod.AIM_ROOT = aim_root
+        result = self.mod.find_transcripts()
+        self.assertIn(p, result)
+
+    def test_returns_sorted_by_mtime(self):
+        aim_root = self.tmp
+        proj_hash = "-" + aim_root.lstrip("/").replace("/", "-")
+        proj_dir = os.path.expanduser(f"~/.claude/projects/{proj_hash}")
+        os.makedirs(proj_dir, exist_ok=True)
+        p1 = os.path.join(proj_dir, "old.jsonl")
+        p2 = os.path.join(proj_dir, "new.jsonl")
+        _make_jsonl(p1, [_user("old")])
+        import time; time.sleep(0.01)
+        _make_jsonl(p2, [_user("new")])
+        self.mod.AIM_ROOT = aim_root
+        result = self.mod.find_transcripts()
+        self.assertEqual(result[-1], p2)
+
+
+class TestExtractLastTurns(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def _write(self, turns, name="sess.jsonl"):
+        p = os.path.join(self.tmp, name)
+        _make_jsonl(p, turns)
+        return p
+
+    def test_extracts_user_and_assistant(self):
+        p = self._write([_user("hello"), _assistant("hi back")])
+        turns = self.mod.extract_last_turns(p, n=5)
+        self.assertEqual(len(turns), 2)
+        self.assertEqual(turns[0]["role"], "user")
+        self.assertEqual(turns[1]["role"], "assistant")
+
+    def test_skips_snapshots(self):
+        p = self._write([_snapshot(), _user("real turn")])
+        turns = self.mod.extract_last_turns(p, n=5)
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0]["role"], "user")
+
+    def test_skips_tool_results(self):
+        p = self._write([_tool_result(), _user("real")])
+        turns = self.mod.extract_last_turns(p, n=5)
+        self.assertEqual(len(turns), 1)
+
+    def test_returns_last_n_only(self):
+        many = [_user(f"msg {i}") for i in range(10)]
+        p = self._write(many)
+        turns = self.mod.extract_last_turns(p, n=5)
+        self.assertEqual(len(turns), 5)
+        self.assertEqual(turns[-1]["text"], "msg 9")
+
+    def test_returns_all_when_fewer_than_n(self):
+        p = self._write([_user("only one")])
+        turns = self.mod.extract_last_turns(p, n=5)
+        self.assertEqual(len(turns), 1)
+
+
+class TestAntiCannibalization(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_skips_tiny_newest_uses_previous(self):
+        p1 = os.path.join(self.tmp, "big.jsonl")
+        p2 = os.path.join(self.tmp, "tiny.jsonl")
+        _make_jsonl(p1, [_user(f"turn {i}") for i in range(20)])
+        import time; time.sleep(0.01)
+        _make_jsonl(p2, [_user("just woke up")])  # < 15 lines
+
+        result = self.mod.select_transcript([p1, p2])
+        self.assertEqual(result, p1)
+
+    def test_uses_newest_when_large_enough(self):
+        p1 = os.path.join(self.tmp, "old.jsonl")
+        p2 = os.path.join(self.tmp, "new.jsonl")
+        _make_jsonl(p1, [_user(f"t{i}") for i in range(20)])
+        import time; time.sleep(0.01)
+        _make_jsonl(p2, [_user(f"t{i}") for i in range(20)])
+
+        result = self.mod.select_transcript([p1, p2])
+        self.assertEqual(result, p2)
+
+    def test_uses_only_file_even_if_tiny(self):
+        p1 = os.path.join(self.tmp, "only.jsonl")
+        _make_jsonl(p1, [_user("short")])
+        result = self.mod.select_transcript([p1])
+        self.assertEqual(result, p1)
+
+
+class TestWriteCurrentPulse(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_writes_pulse_file(self):
+        turns = [{"role": "user", "text": "hello", "timestamp": "T"},
+                 {"role": "assistant", "text": "hi", "timestamp": "T"}]
+        self.mod.write_current_pulse(turns)
+        pulse_path = os.path.join(self.tmp, "continuity", "CURRENT_PULSE.md")
+        self.assertTrue(os.path.exists(pulse_path))
+
+    def test_pulse_contains_user_text(self):
+        turns = [{"role": "user", "text": "what is the plan", "timestamp": "T"}]
+        self.mod.write_current_pulse(turns)
+        content = open(os.path.join(self.tmp, "continuity", "CURRENT_PULSE.md")).read()
+        self.assertIn("what is the plan", content)
+
+    def test_pulse_contains_assistant_text(self):
+        turns = [{"role": "assistant", "text": "the plan is X", "timestamp": "T"}]
+        self.mod.write_current_pulse(turns)
+        content = open(os.path.join(self.tmp, "continuity", "CURRENT_PULSE.md")).read()
+        self.assertIn("the plan is X", content)
+
+    def test_pulse_has_yaml_frontmatter(self):
+        self.mod.write_current_pulse([])
+        content = open(os.path.join(self.tmp, "continuity", "CURRENT_PULSE.md")).read()
+        self.assertTrue(content.startswith("---"))
+        self.assertIn("type: handoff", content)
+
+    def test_pulse_no_llm_call(self):
+        """write_current_pulse must never call generate_reasoning."""
+        with patch("builtins.__import__") as mock_import:
+            turns = [{"role": "user", "text": "hi", "timestamp": "T"}]
+            self.mod.write_current_pulse(turns)
+            # If generate_reasoning were called, it would need reasoning_utils import
+            # We just verify the file was written without error
+        pulse_path = os.path.join(self.tmp, "continuity", "CURRENT_PULSE.md")
+        self.assertTrue(os.path.exists(pulse_path))
+
+
+class TestWriteHandoff(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_writes_handoff_file(self):
+        self.mod.write_handoff()
+        self.assertTrue(os.path.exists(self.mod.HANDOFF_PATH))
+
+    def test_handoff_contains_timestamp(self):
+        self.mod.write_handoff()
+        content = open(self.mod.HANDOFF_PATH).read()
+        self.assertIn(datetime.now().strftime("%Y-%m-%d"), content)
+
+    def test_handoff_contains_reading_order(self):
+        self.mod.write_handoff()
+        content = open(self.mod.HANDOFF_PATH).read()
+        self.assertIn("REINCARNATION_GAMEPLAN.md", content)
+        self.assertIn("CURRENT_PULSE.md", content)
+        self.assertIn("ISSUE_TRACKER.md", content)
+
+    def test_handoff_is_static_template(self):
+        """Two calls produce identical content except for the timestamp."""
+        self.mod.write_handoff()
+        c1 = open(self.mod.HANDOFF_PATH).read()
+        self.mod.write_handoff()
+        c2 = open(self.mod.HANDOFF_PATH).read()
+        # Strip timestamp lines for comparison
+        strip = lambda s: "\n".join(l for l in s.splitlines() if "Timestamp" not in l)
+        self.assertEqual(strip(c1), strip(c2))
+
+
+class TestMainPulse(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_graceful_when_no_transcripts(self):
+        """main() must not raise when no JSONL files exist."""
+        self.mod.find_transcripts = MagicMock(return_value=[])
+        try:
+            self.mod.main()
+        except Exception as e:
+            self.fail(f"main() raised with no transcripts: {e}")
+
+    def test_writes_handoff_even_with_no_transcripts(self):
+        """HANDOFF.md must always be refreshed, even if pulse is empty."""
+        self.mod.find_transcripts = MagicMock(return_value=[])
+        self.mod.main()
+        self.assertTrue(os.path.exists(self.mod.HANDOFF_PATH))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`handoff_pulse_generator.py` reads from `~/.gemini/tmp/` — doesn't exist for Claude Code. `CURRENT_PULSE.md` was never being written. This fix replaces it with a local Claude-specific script.

## Changes

- **`scripts/handoff_pulse_claude.py`** (new local file — not a symlink):
  - Discovers JSONL from `~/.claude/projects/<hash>/` using same hash derivation as `session_summarizer.py`
  - Anti-cannibalization: newest JSONL < 15 lines → uses previous session
  - Extracts last 5 user+assistant turns — no LLM, pure mechanical extraction
  - Writes `CURRENT_PULSE.md` with YAML frontmatter + formatted turns
  - Refreshes `HANDOFF.md` from a static template (only timestamp changes)

- **`scripts/aim_reincarnate.py`**: calls `handoff_pulse_claude.py` instead of `src/handoff_pulse_generator.py`

## TDD
22 new tests for `handoff_pulse_claude.py` + 2 new `aim_reincarnate` tests. All GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)