### PR TITLE
Fix: Add LAST_SESSION_FLIGHT_RECORDER.md write to handoff_pulse_claude.py (Closes #84)

### DIFF
--- a/scripts/handoff_pulse_claude.py
+++ b/scripts/handoff_pulse_claude.py
@@ -8,7 +8,8 @@ Responsibilities:
   1. Find the current session JSONL from ~/.claude/projects/<hash>/
   2. Extract the last 5 user+assistant turns (no LLM — pure mechanical extraction)
   3. Write CURRENT_PULSE.md
-  4. Refresh HANDOFF.md from a static template (timestamp only changes)
+  4. Write LAST_SESSION_FLIGHT_RECORDER.md (full session history or rolling delta)
+  5. Refresh HANDOFF.md from a static template (timestamp only changes)
 
 Anti-cannibalization: if the newest JSONL has < 15 lines (e.g. a fresh wake-up
 session), use the previous one so we don't overwrite a full history with a stub.
@@ -205,6 +206,35 @@ def write_current_pulse(turns):
     _atomic_write(os.path.join(CONTINUITY_DIR, "CURRENT_PULSE.md"), "\n".join(lines))
 
 
+def write_flight_recorder(turns, context_lines=0):
+    """Write LAST_SESSION_FLIGHT_RECORDER.md from extracted turns — no LLM.
+
+    Args:
+        turns: List of dicts {role, text, timestamp} — full session history.
+        context_lines: 0 = full history, >0 = rolling delta (last N lines of body).
+    """
+    body_lines = []
+    for turn in turns:
+        role_label = "USER" if turn["role"] == "user" else "A.I.M."
+        ts = turn.get("timestamp", "")
+        body_lines.append(f"### {role_label} ({ts})")
+        body_lines.append(turn["text"])
+        body_lines.append("")
+
+    if context_lines > 0 and len(body_lines) > context_lines:
+        truncated = body_lines[-context_lines:]
+        header = "# A.I.M. Session Flight Recorder (Rolling Delta)\n"
+        header += f"*This is a noise-reduced flight recorder showing only the last {context_lines} lines. NOT automatically injected into LLM context.*\n\n"
+        content = header + "\n".join(truncated) + "\n"
+    else:
+        header = "# A.I.M. Session Flight Recorder (Full History)\n"
+        header += "*This is a noise-reduced flight recorder showing the entire session. NOT automatically injected into LLM context.*\n\n"
+        content = header + "\n".join(body_lines) + "\n"
+
+    os.makedirs(CONTINUITY_DIR, exist_ok=True)
+    _atomic_write(os.path.join(CONTINUITY_DIR, "LAST_SESSION_FLIGHT_RECORDER.md"), content)
+
+
 def write_handoff():
     """Refresh HANDOFF.md from the static template with a current timestamp."""
     content = HANDOFF_TEMPLATE.format(
@@ -222,13 +252,26 @@ def main():
 
     if transcript:
         turns = extract_last_turns(transcript, n=5)
+        all_turns = extract_last_turns(transcript, n=sys.maxsize)
     else:
         turns = []
+        all_turns = []
         print("[handoff_pulse_claude] No JSONL transcripts found — writing empty pulse.")
 
+    # Load configurable line limit for flight recorder (0 = full history)
+    context_lines = 0
+    config_path = os.path.join(AIM_ROOT, "core", "CONFIG.json")
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        context_lines = config.get("settings", {}).get("handoff_context_lines", 0)
+    except Exception:
+        pass
+
     write_current_pulse(turns)
+    write_flight_recorder(all_turns, context_lines=context_lines)
     write_handoff()
-    print("[handoff_pulse_claude] CURRENT_PULSE.md and HANDOFF.md refreshed.")
+    print("[handoff_pulse_claude] CURRENT_PULSE.md, LAST_SESSION_FLIGHT_RECORDER.md, and HANDOFF.md refreshed.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_handoff_pulse_claude.py
+++ b/tests/unit/test_handoff_pulse_claude.py
@@ -256,6 +256,57 @@ class TestWriteHandoff(unittest.TestCase):
         self.assertEqual(strip(c1), strip(c2))
 
 
+class TestWriteFlightRecorder(unittest.TestCase):
+    def setUp(self):
+        self.tmp = _make_tmp_root()
+        self.mod = _load_mod(self.tmp)
+
+    def test_writes_flight_recorder_file(self):
+        turns = [{"role": "user", "text": "hello", "timestamp": "T1"},
+                 {"role": "assistant", "text": "hi back", "timestamp": "T2"}]
+        self.mod.write_flight_recorder(turns)
+        fr_path = os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")
+        self.assertTrue(os.path.exists(fr_path))
+
+    def test_flight_recorder_contains_all_turns(self):
+        turns = [{"role": "user", "text": f"msg {i}", "timestamp": f"T{i}"} for i in range(20)]
+        self.mod.write_flight_recorder(turns)
+        content = open(os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")).read()
+        for i in range(20):
+            self.assertIn(f"msg {i}", content)
+
+    def test_flight_recorder_has_header(self):
+        turns = [{"role": "user", "text": "hello", "timestamp": "T1"}]
+        self.mod.write_flight_recorder(turns)
+        content = open(os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")).read()
+        self.assertIn("Flight Recorder", content)
+
+    def test_flight_recorder_rolling_delta(self):
+        """When handoff_context_lines > 0, only the last N lines are kept."""
+        turns = [{"role": "user", "text": f"msg {i}", "timestamp": f"T{i}"} for i in range(50)]
+        self.mod.write_flight_recorder(turns, context_lines=10)
+        content = open(os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")).read()
+        self.assertIn("Rolling Delta", content)
+        # The body (after header) should be at most 10 lines
+        body_lines = [l for l in content.splitlines() if l.strip() and not l.startswith("#") and not l.startswith("*")]
+        self.assertLessEqual(len(body_lines), 10)
+
+    def test_flight_recorder_full_history_when_zero(self):
+        turns = [{"role": "user", "text": f"msg {i}", "timestamp": f"T{i}"} for i in range(20)]
+        self.mod.write_flight_recorder(turns, context_lines=0)
+        content = open(os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")).read()
+        self.assertIn("Full History", content)
+        self.assertIn("msg 0", content)
+        self.assertIn("msg 19", content)
+
+    def test_flight_recorder_empty_turns(self):
+        self.mod.write_flight_recorder([])
+        fr_path = os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")
+        self.assertTrue(os.path.exists(fr_path))
+        content = open(fr_path).read()
+        self.assertIn("Flight Recorder", content)
+
+
 class TestMainPulse(unittest.TestCase):
     def setUp(self):
         self.tmp = _make_tmp_root()
@@ -274,6 +325,26 @@ class TestMainPulse(unittest.TestCase):
         self.mod.find_transcripts = MagicMock(return_value=[])
         self.mod.main()
         self.assertTrue(os.path.exists(self.mod.HANDOFF_PATH))
+
+    def test_main_writes_flight_recorder(self):
+        """main() must write LAST_SESSION_FLIGHT_RECORDER.md."""
+        jsonl_path = os.path.join(self.tmp, "session.jsonl")
+        turns = [_user(f"turn {i}") for i in range(20)]
+        _make_jsonl(jsonl_path, turns)
+        self.mod.find_transcripts = MagicMock(return_value=[jsonl_path])
+        self.mod.main()
+        fr_path = os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")
+        self.assertTrue(os.path.exists(fr_path), "main() did not write LAST_SESSION_FLIGHT_RECORDER.md")
+        content = open(fr_path).read()
+        self.assertIn("Flight Recorder", content)
+        self.assertIn("turn 0", content)
+
+    def test_main_writes_flight_recorder_even_without_transcripts(self):
+        """Flight recorder should still be written (empty) when no transcripts found."""
+        self.mod.find_transcripts = MagicMock(return_value=[])
+        self.mod.main()
+        fr_path = os.path.join(self.tmp, "continuity", "LAST_SESSION_FLIGHT_RECORDER.md")
+        self.assertTrue(os.path.exists(fr_path))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `handoff_pulse_claude.py` (written for #78) replaced the Gemini-era pulse generator but omitted the `LAST_SESSION_FLIGHT_RECORDER.md` write entirely
- Adds `write_flight_recorder()` — extracts ALL session turns from JSONL and writes full history (or rolling delta per `handoff_context_lines` in CONFIG.json)
- Wired into `main()` so it runs alongside CURRENT_PULSE.md and HANDOFF.md on every reincarnation

## Test plan
- [x] 8 new unit tests covering: file creation, all-turns inclusion, header format, rolling delta mode, full history mode, empty turns
- [x] 2 integration tests: `main()` writes flight recorder with/without transcripts
- [x] All 30 tests pass (22 existing + 8 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)