### PR TITLE
Decouple: Phase 2 — break skills/ symlink (Epic #86)

### DIFF
--- a/skills/advanced_memory_search.py
+++ b/skills/advanced_memory_search.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import sys, json, os
+from pathlib import Path
+
+def _find_aim_root():
+    current = os.path.abspath(os.getcwd())
+    while current != '/':
+        if os.path.exists(os.path.join(current, "core", "CONFIG.json")):
+            return current
+        current = os.path.dirname(current)
+    return str(Path(__file__).parent.parent)
+
+aim_root = Path(_find_aim_root())
+sys.path.append(str(aim_root / "src"))
+
+from plugins.datajack.forensic_utils import ForensicDB, get_embedding
+
+try:
+    args_json = sys.argv[1] if len(sys.argv) > 1 else "{}"
+    args = json.loads(args_json)
+    query = args.get("query", "latest changes")
+    top_k = int(args.get("top_k", 10))
+    
+    db = ForensicDB()
+    
+    query_vec = get_embedding(query, task_type='RETRIEVAL_QUERY')
+    semantic_results = []
+    if query_vec:
+        semantic_results = db.search_fragments(query_vec, top_k=top_k)
+    lexical_results = db.search_lexical(query, top_k=top_k)
+    db.close()
+    
+    # Simple merge
+    all_results = semantic_results + lexical_results
+    
+    print(json.dumps({"results": all_results}, indent=2))
+except Exception as e:
+    print(json.dumps({"error": str(e)}))

--- a/skills/advanced_memory_search_SKILL.md
+++ b/skills/advanced_memory_search_SKILL.md
@@ -1,0 +1,12 @@
+# SKILL: advanced_memory_search
+
+**Name:** advanced_memory_search  
+**Description:** Runs a deep hybrid (semantic + FTS5) search across the entire Engram DB — perfect for "what did we decide about X last week?"  
+**Type:** Python  
+**Arguments:**  
+- `query` (string, required) — natural language or keyword search
+
+**Example call:**
+```json
+{"name": "run_skill", "arguments": {"skill_name": "advanced_memory_search", "args_json": "{\"query\": \"user prefers dark mode\"}"}}
+```

--- a/skills/export_datajack_cartridge.py
+++ b/skills/export_datajack_cartridge.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import sys, json, subprocess, os
+from pathlib import Path
+
+def _find_aim_root():
+    current = os.path.abspath(os.getcwd())
+    while current != '/':
+        if os.path.exists(os.path.join(current, "core", "CONFIG.json")):
+            return current
+        current = os.path.dirname(current)
+    return str(Path(__file__).parent.parent)
+
+aim_root = Path(_find_aim_root())
+aim_exchange = aim_root / "scripts" / "aim_exchange.py"
+
+try:
+    arg_input = sys.argv[1] if len(sys.argv) > 1 else "{}"
+    try:
+        args = json.loads(arg_input)
+        if isinstance(args, dict):
+            keyword = args.get("keyword", "expert-")
+            out_name = args.get("name", "export.engram")
+        else:
+            keyword = str(args)
+            out_name = sys.argv[2] if len(sys.argv) > 2 else f"{keyword}.engram"
+    except (json.JSONDecodeError, TypeError, ValueError):
+        # Fallback: Assume the user passed raw string arguments via CLI
+        keyword = sys.argv[1]
+        out_name = sys.argv[2] if len(sys.argv) > 2 else f"{keyword}.engram"
+    
+    if not out_name.endswith(".engram"): out_name += ".engram"
+    
+    result = subprocess.run(
+        [sys.executable, str(aim_exchange), "export", keyword, "--out", out_name],
+        capture_output=True,
+        text=True,
+        cwd=aim_root
+    )
+    print(json.dumps({
+        "status": "Export Complete",
+        "output": result.stdout.strip(),
+        "error": result.stderr.strip(),
+        "file": out_name
+    }, indent=2))
+except Exception as e:
+    print(json.dumps({"error": str(e)}))

--- a/skills/export_datajack_cartridge_SKILL.md
+++ b/skills/export_datajack_cartridge_SKILL.md
@@ -1,0 +1,13 @@
+# SKILL: export_datajack_cartridge
+
+**Name:** export_datajack_cartridge  
+**Description:** Packages specific knowledge from the Engram DB into a portable .engram DataJack cartridge for sharing or backup.  
+**Type:** Python  
+**Arguments:**  
+- `keyword` (string, required) — The keyword to search for in session filenames (e.g., "python", "expert-")
+- `name` (string, optional) — cartridge filename output
+
+**Example call:** 
+```json
+{"name": "run_skill", "arguments": {"skill_name": "export_datajack_cartridge", "args_json": "{\"keyword\":\"python\", \"name\":\"python314.engram\"}"}}
+```

--- a/skills/list_recent_sessions.py
+++ b/skills/list_recent_sessions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+import sqlite3
+from pathlib import Path
+
+def _find_aim_root():
+    current = os.path.abspath(os.getcwd())
+    while current != '/':
+        if os.path.exists(os.path.join(current, "core", "CONFIG.json")):
+            return current
+        current = os.path.dirname(current)
+    return str(Path(__file__).parent.parent)
+
+def main():
+    # Accept limit from CLI arg or default
+    limit = 5
+    if len(sys.argv) > 1:
+        try:
+            args = json.loads(sys.argv[1])
+            limit = int(args.get("limit", 5))
+        except:
+            pass
+
+    aim_root = Path(_find_aim_root())
+    db_path = aim_root / "archive" / "engram.db"
+    
+    if not db_path.exists():
+        print(json.dumps({"error": "engram.db not found"}))
+        sys.exit(1)
+    
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cur = conn.cursor()
+    
+    # We query the sessions table. Note: 'fragment_count' is calculated via a subquery.
+    cur.execute("""
+        SELECT 
+            s.id as session_id, 
+            s.indexed_at as timestamp, 
+            (SELECT COUNT(*) FROM fragments f WHERE f.session_id = s.id) as fragment_count
+        FROM sessions s
+        ORDER BY s.indexed_at DESC 
+        LIMIT ?
+    """, (limit,))
+    
+    rows = cur.fetchall()
+    result = {
+        "sessions": [
+            {
+                "session_id": r["session_id"],
+                "timestamp": r["timestamp"],
+                "fragments": r["fragment_count"]
+            } for r in rows
+        ]
+    }
+    
+    print(json.dumps(result, indent=2))
+    conn.close()
+
+if __name__ == "__main__":
+    main()

--- a/skills/list_recent_sessions_SKILL.md
+++ b/skills/list_recent_sessions_SKILL.md
@@ -1,0 +1,17 @@
+# SKILL: list_recent_sessions
+
+**Name:** list_recent_sessions  
+**Description:** Returns the N most recent sessions from the Engram DB (perfect for agents that want to know "what have we worked on lately").  
+**Type:** Python  
+**Arguments:**
+- `limit` (integer, default 5) — how many recent sessions to return
+
+**Example call (from any MCP-aware CLI):**
+```json
+{
+  "name": "list_recent_sessions",
+  "arguments": { "limit": 10 }
+}
+```
+
+**Returns:** JSON with session_id, timestamp, and fragment count.

--- a/skills/propose_memory_commit.py
+++ b/skills/propose_memory_commit.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import sys, json, subprocess, os
+from pathlib import Path
+
+def _find_aim_root():
+    current = os.path.abspath(os.getcwd())
+    while current != '/':
+        if os.path.exists(os.path.join(current, "core", "CONFIG.json")):
+            return current
+        current = os.path.dirname(current)
+    return str(Path(__file__).parent.parent)
+
+aim_root = Path(_find_aim_root())
+aim_cli = aim_root / "scripts" / "aim_cli.py"
+
+try:
+    print(json.dumps({"status": "Triggering memory refinement pipeline. This may take a minute."}))
+    # We call aim memory which fires Tier 2 -> 3 -> 4
+    result = subprocess.run(
+        [sys.executable, str(aim_cli), "memory"],
+        capture_output=True,
+        text=True
+    )
+    print(json.dumps({
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip()
+    }, indent=2))
+except Exception as e:
+    print(json.dumps({"error": str(e)}))

--- a/skills/propose_memory_commit_SKILL.md
+++ b/skills/propose_memory_commit_SKILL.md
@@ -1,0 +1,11 @@
+# SKILL: propose_memory_commit
+
+**Name:** propose_memory_commit  
+**Description:** Runs the full 4-tier distillation (aim memory) and returns a ready-to-apply MEMORY.md diff in the proposals folder.  
+**Type:** Python  
+**Arguments:** none
+
+**Example call:** 
+```json
+{"name": "run_skill", "arguments": {"skill_name": "propose_memory_commit"}}
+```

--- a/tests/unit/test_issue_59_regression.py
+++ b/tests/unit/test_issue_59_regression.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 AIM_CLAUDE_ROOT = str(Path(__file__).parent.parent.parent)
-AIM_SKILLS = os.path.join(AIM_CLAUDE_ROOT, "skills")  # symlink → /home/kingb/aim/skills
+AIM_SKILLS = os.path.join(AIM_CLAUDE_ROOT, "skills")  # local directory (decoupled from shared aim/)
 
 
 # ---------------------------------------------------------------------------
@@ -72,8 +72,8 @@ def _assert_aim_root_correct(mod, label):
         f"{label}: _find_aim_root() returned {result!r}, expected {AIM_CLAUDE_ROOT!r}. "
         "The __file__-parent bug may have regressed."
     )
-    # Verify it's NOT the bare aim/ repo
-    aim_bare = str(Path(AIM_SKILLS).resolve().parent)  # /home/kingb/aim
+    # Verify it's NOT the bare aim/ repo (the shared swarm repo)
+    aim_bare = "/home/kingb/aim"
     assert result != aim_bare, (
         f"{label}: resolved to bare aim/ repo instead of aim-claude/"
     )
@@ -131,7 +131,7 @@ class TestProposeMemoryCommitAimRoot:
             root = mod._find_aim_root()
         expected_cli = os.path.join(root, "scripts", "aim_cli.py")
         # The script should not be pointing into bare aim/
-        aim_bare = str(Path(AIM_SKILLS).resolve().parent)
+        aim_bare = "/home/kingb/aim"
         assert not expected_cli.startswith(aim_bare + "/scripts"), (
             f"aim_cli path resolves into bare aim/ repo: {expected_cli!r}"
         )


### PR DESCRIPTION
## Summary
- Break `skills/` symlink, copy all 4 skill scripts + manifests locally
- Add cwd-first `_find_aim_root()` to all skills (fixes issue #59 regression)
- Update `test_issue_59_regression.py` guards for decoupled (non-symlinked) skills directory

Part of Epic #86.

## Test plan
- [x] 10/10 issue-59 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)